### PR TITLE
🎨 Palette: Accessible Toggle Buttons & Form Helpers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-08 - Linking Descriptions with aria-describedby
 **Learning:** Input fields often have helper text in `<span>` tags. These are invisible to screen readers unless programmatically linked.
 **Action:** Always add `id` to the helper text span and `aria-describedby="[id]"` to the input field. This is a low-effort, high-impact accessibility win.
+
+## 2026-01-08 - Accessible Toggle Buttons
+**Learning:** Custom buttons acting as mode switches need state indication for screen readers. `aria-pressed` is a simple way to indicate "on/off" status for toggle buttons.
+**Action:** When implementing view toggles, add `aria-pressed="true/false"` and `aria-controls="[target-id]"`. Ensure JavaScript updates the `aria-pressed` state on click.

--- a/templates/index.html
+++ b/templates/index.html
@@ -130,8 +130,10 @@
       </div>
       <div style="display: flex; gap: 10px;">
         <button onclick="switchMode('manual')" id="btn-manual" class="btn btn-primary"
+          aria-pressed="true" aria-controls="manual-panel"
           style="font-size: 0.8rem; padding: 10px 20px;">Manual Mode</button>
         <button onclick="switchMode('live')" id="btn-live" class="btn"
+          aria-pressed="false" aria-controls="live-panel"
           style="font-size: 0.8rem; padding: 10px 20px; border: 1px solid var(--glass-border);">Live Monitor</button>
       </div>
     </div>
@@ -223,8 +225,8 @@
         <div class="form-grid">
           <div class="form-group">
             <label for="count">Connection Count (Same Host)</label>
-            <input type="number" name="count" id="count" min="0" placeholder="e.g. 5" required />
-            <span class="input-description">Number of connections to target host</span>
+            <input type="number" name="count" id="count" min="0" placeholder="e.g. 5" required aria-describedby="count-desc" />
+            <span class="input-description" id="count-desc">Number of connections to target host</span>
           </div>
 
           <div class="form-group">
@@ -333,7 +335,12 @@
       const btnManual = document.getElementById('btn-manual');
       const btnLive = document.getElementById('btn-live');
 
-      if (mode === 'live') {
+      const isLive = mode === 'live';
+
+      btnLive.setAttribute('aria-pressed', isLive);
+      btnManual.setAttribute('aria-pressed', !isLive);
+
+      if (isLive) {
         manualPanel.style.display = 'none';
         livePanel.style.display = 'block';
         btnLive.classList.add('btn-primary');


### PR DESCRIPTION
🎨 Palette: Improved accessibility for the Command Center interface.

💡 **What:**
- Added `aria-pressed` state to the "Manual Mode" and "Live Monitor" toggle buttons.
- Added `aria-controls` to link buttons to their respective panels.
- Linked the helper text "Number of connections to target host" to the input field using `aria-describedby`.
- Updated JavaScript to dynamically toggle the `aria-pressed` attribute.

🎯 **Why:**
- Screen reader users had no way of knowing which mode was active or that the buttons were toggles.
- The helper text for the connection count was visually present but programmatically disconnected from the input.

♿ **Accessibility:**
- **Buttons:** Now announce "pressed" state and what they control.
- **Forms:** Helper text is now announced when the input receives focus.


---
*PR created automatically by Jules for task [8699315120197197816](https://jules.google.com/task/8699315120197197816) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive accessibility guidance for toggle button controls, covering proper state indication mechanisms and targeted element associations for users relying on assistive technologies

* **Bug Fixes**
  * Enhanced mode toggle button accessibility with proper on/off state indicators and explicit control target references
  * Improved count input field accessibility with semantic descriptive associations and labeling support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->