### PR TITLE
🎨 Palette: Add accessible meter role to threat gauge

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-01-31 - Accessible Live Logs
 **Learning:** Dynamic log updates (e.g., scrolling terminals) are invisible to screen readers without specific roles. Also, `overflow: auto` divs are not keyboard-focusable by default.
 **Action:** Use `role="log"` and `aria-live="polite"` for the container. Add `tabindex="0"` to ensure keyboard users can focus and scroll the log history.
+
+## 2026-06-15 - Dynamic Meter Accessibility
+**Learning:** Visual gauges showing percentage (like threat levels) need `role="meter"` and programmatic updates to `aria-valuenow`.
+**Action:** When updating the visual text of a gauge in JS, always update `aria-valuenow` and `aria-valuetext` to ensure screen readers receive the same live data.

--- a/templates/index.html
+++ b/templates/index.html
@@ -156,7 +156,7 @@
         <div class="glass-card"
           style="padding: 30px; text-align: center; display: flex; flex-direction: column; justify-content: center;">
           <h3 style="font-size: 1rem; color: var(--text-muted); text-transform: uppercase;">Threat Level</h3>
-          <div id="threat-gauge" style="font-size: 3rem; font-weight: 800; margin: 20px 0; color: #00ff88;">0%</div>
+          <div id="threat-gauge" role="meter" aria-label="Threat Risk Level" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0% - Low Risk" style="font-size: 3rem; font-weight: 800; margin: 20px 0; color: #00ff88;">0%</div>
           <div style="font-size: 0.8rem; color: var(--text-muted);">Risk Concentration</div>
         </div>
       </div>
@@ -437,8 +437,14 @@
 
       // Update Gauge
       if (threatGauge) {
-        threatGauge.textContent = Math.round(value) + '%';
+        const roundedValue = Math.round(value);
+        threatGauge.textContent = roundedValue + '%';
         threatGauge.style.color = value > 50 ? '#ff007a' : '#00ff88';
+
+        // Update ARIA attributes
+        threatGauge.setAttribute('aria-valuenow', roundedValue);
+        const riskLevel = value > 50 ? 'High Risk' : 'Low Risk';
+        threatGauge.setAttribute('aria-valuetext', `${roundedValue}% - ${riskLevel}`);
       }
 
       // Update Chart

--- a/verification/verify_meter.py
+++ b/verification/verify_meter.py
@@ -1,0 +1,99 @@
+import time
+import subprocess
+import os
+import signal
+import sys
+from playwright.sync_api import sync_playwright
+
+def verify_live_monitor_meter():
+    # Start the mock app in the background
+    # We use setsid to create a new process group so we can kill the whole tree later
+    server_process = subprocess.Popen(
+        [sys.executable, "mock_app.py"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=os.setsid
+    )
+
+    # Give the server a moment to start
+    time.sleep(3)
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+
+            # Navigate to the page
+            print("Navigating to http://127.0.0.1:5000/ids")
+            try:
+                page.goto("http://127.0.0.1:5000/ids")
+            except Exception as e:
+                print(f"Failed to connect to server: {e}")
+                return
+
+            # Click 'Live Monitor' to reveal the panel
+            print("Clicking 'Live Monitor'...")
+            page.get_by_role("button", name="Live Monitor").click()
+
+            # Wait for panel to be visible
+            live_panel = page.locator("#live-panel")
+            live_panel.wait_for(state="visible")
+
+            # Locate the gauge
+            gauge = page.locator("#threat-gauge")
+
+            # Verify initial static attributes
+            print("Verifying initial attributes...")
+            assert gauge.get_attribute("role") == "meter", "Role should be 'meter'"
+            assert gauge.get_attribute("aria-valuemin") == "0", "aria-valuemin should be '0'"
+            assert gauge.get_attribute("aria-valuemax") == "100", "aria-valuemax should be '100'"
+
+            # Wait for dynamic update (polling every 3s in app, we wait up to 5s)
+            print("Waiting for dynamic update...")
+
+            # We expect aria-valuenow to change from initial "0" to something else
+            # mock_app.py returns "Normal", so value will be 5-15 roughly.
+
+            def check_update():
+                val_now = gauge.get_attribute("aria-valuenow")
+                val_text = gauge.get_attribute("aria-valuetext")
+                if val_now and val_now != "0" and val_text and "Low Risk" in val_text:
+                    return True
+                return False
+
+            # Poll for the update
+            updated = False
+            for i in range(10): # wait up to 10 seconds
+                if check_update():
+                    updated = True
+                    break
+                print(f"Waiting... ({i+1}/10)")
+                time.sleep(1)
+
+            if not updated:
+                print("Gauge did not update as expected.")
+                print("Current valuenow:", gauge.get_attribute("aria-valuenow"))
+                print("Current valuetext:", gauge.get_attribute("aria-valuetext"))
+
+            assert updated, "Gauge attributes should update dynamically"
+
+            print("Gauge updated successfully!")
+            print(f"aria-valuenow: {gauge.get_attribute('aria-valuenow')}")
+            print(f"aria-valuetext: {gauge.get_attribute('aria-valuetext')}")
+
+            # Take screenshot
+            screenshot_path = "/home/jules/verification/live_monitor_meter.png"
+            page.screenshot(path=screenshot_path)
+            print(f"Screenshot saved to {screenshot_path}")
+
+            browser.close()
+
+    finally:
+        # Kill the server process group
+        try:
+            os.killpg(os.getpgid(server_process.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+if __name__ == "__main__":
+    verify_live_monitor_meter()


### PR DESCRIPTION
This PR enhances the accessibility of the live monitor's Threat Intensity Gauge. Previously, it was a simple `div` that updated text content, which is opaque to screen readers regarding its semantic meaning (a meter/gauge) and boundaries.

Changes:
1.  **Semantic HTML:** Added `role="meter"`, `aria-valuemin="0"`, `aria-valuemax="100"` to `#threat-gauge`.
2.  **Dynamic Updates:** The JavaScript `updateLiveUI` function now updates `aria-valuenow` and sets a descriptive `aria-valuetext` (e.g., "75% - High Risk") whenever the visual value changes.
3.  **Verification:** Added a Playwright script `verification/verify_meter.py` to ensure these attributes are correctly applied and updated.

This ensures screen reader users can perceive the threat level as a structured value with context.

---
*PR created automatically by Jules for task [11320813489597240619](https://jules.google.com/task/11320813489597240619) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved threat gauge accessibility in Live Monitor: the gauge now properly announces changes to screen readers, dynamically updating with the current percentage and corresponding risk level (Low/High Risk).
  * Enhanced gauge display to show rounded percentage values alongside visual risk indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->